### PR TITLE
Fix documentation for configuring the MCP in VS Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ Sample `.vscode/mcp.json`
         "run",
         "--rm",
         "-i",
+        "--env",
+        "CORTEX_API_TOKEN",
         "ghcr.io/cortexapps/cortex-mcp:latest"
       ],
       "env": {


### PR DESCRIPTION
Docker, by default, does not pass through environment variables. Thus, when passing the Cortex API token via an environment variable, we need to ask the Docker command to pass it through. Otherwise, access to Cortex will fail with a 401 error.