### PR TITLE
fix: preserve schema definitions in generated MCP tools

### DIFF
--- a/src/components/customizers.py
+++ b/src/components/customizers.py
@@ -53,12 +53,7 @@ def customize_components(
 
         if hasattr(component, 'parameters') and isinstance(component.parameters, dict):
             if "$defs" in component.parameters:
-                logger.debug(f"  Found $defs with {len(component.parameters['$defs'])} definitions")
-                new_params = {k: v for k, v in component.parameters.items() if k != "$defs"}
-                component.parameters = new_params
-                logger.debug(f"  After modification: '$defs' in parameters = {'$defs' in component.parameters}")
-                mcp_tool = component.to_mcp_tool()
-                logger.debug(f"  In to_mcp_tool result: '$defs' in inputSchema = {'$defs' in mcp_tool.inputSchema}")
+                logger.debug(f"  Found $defs with {len(component.parameters['$defs'])} definitions - preserving them")
 
         # Handle output_schema the same way
         if hasattr(component, 'output_schema') and isinstance(component.output_schema, dict):


### PR DESCRIPTION
The customizer was removing schema definitions ($defs) from MCP tool input schemas, leaving schema references dangling and causing "PointerToNowhere" errors when schema references couldn't resolve for tools with complex schemas (ie nested references).

ex:

prev
```
  🔧 pointInTimeMetrics: 
    name='pointInTimeMetrics'
    title=None description=None
    inputSchema={
        'type': 'object', 
        'properties': {
            'metrics': {'type': 'array', 'items': {'$ref': '#/$defs/MetricAggregation'}}, // unresolved schema reference -> PointerToNowhere error
            'timeAttribute': {'type': 'string'}
            },
        'required': [ 'metrics']
    }
    outputSchema=None annotations=None meta={'_fastmcp': {'tags': ['cortex-api', 'openapi', 'public-eng-intel-metrics-controller']}}
```

now
```
  🔧 pointInTimeMetrics:
    name='pointInTimeMetrics'
    title=None description=None
    inputSchema={
        'type': 'object',
        'properties': {
            'metrics': {'type': 'array', 'items': {'$ref': '#/$defs/MetricAggregation'}},
            'timeAttribute': {'type': 'string'}},
        'required': ['metrics'],
        // preserve $defs schema definitions
        '$defs': {
            'MetricAggregation': {'required': ['aggregation', 'metric'], 'type': 'object', 'properties': {'aggregation': {'enum': ['SUM', 'AVG', 'COUNT', 'RATIO', 'MIN', 'MAX', 'P50', 'P95', 'RANKING'], 'type': 'string'}, 'metric': {'type': 'string'}}}
        }
    }
    outputSchema=None annotations=None meta={'_fastmcp': {'tags': ['cortex-api', 'openapi', 'public-eng-intel-metrics-controller']}}
```